### PR TITLE
Fix absence not visible across modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,13 @@ type View = 'dashboard' | 'students' | 'attendance' | 'configuration';
 
 function App() {
   const [currentView, setCurrentView] = useState<View>('dashboard');
-  const { students, calculateAttendanceSummary, addStudents } = useAttendance();
+  const {
+    students,
+    calculateAttendanceSummary,
+    addStudents,
+    updateAttendance,
+    getStudentAttendanceForDate
+  } = useAttendance();
 
   const navigationItems = [
     { id: 'dashboard', label: 'Tableau de Bord', icon: Home },
@@ -36,7 +42,13 @@ function App() {
           />
         );
       case 'attendance':
-        return <AttendanceEncoder students={students} />;
+        return (
+          <AttendanceEncoder
+            students={students}
+            updateAttendance={updateAttendance}
+            getStudentAttendanceForDate={getStudentAttendanceForDate}
+          />
+        );
       case 'configuration':
         return <Configuration onStudentsImported={addStudents} />;
       default:

--- a/src/components/AttendanceEncoder.tsx
+++ b/src/components/AttendanceEncoder.tsx
@@ -1,11 +1,21 @@
 import React, { useState, useMemo } from 'react';
 import { Calendar, Save, Mail, Check, Search, Filter, AlertCircle } from 'lucide-react';
 import { Student, AttendanceStatus, STATUS_LABELS, STATUS_COLORS } from '../types';
-import { useAttendance } from '../hooks/useAttendance';
+import { AttendanceRecord } from '../types';
 import { sendEmailToParent, formatDate, getTodayString } from '../utils/emailService';
 
 interface AttendanceEncoderProps {
   students: Student[];
+  getStudentAttendanceForDate: (
+    studentId: string,
+    date: string
+  ) => AttendanceRecord | null;
+  updateAttendance: (
+    studentId: string,
+    date: string,
+    period: 'morning' | 'afternoon',
+    status: AttendanceStatus
+  ) => void;
 }
 
 interface PendingAttendance {
@@ -14,14 +24,17 @@ interface PendingAttendance {
   afternoonStatus: AttendanceStatus;
 }
 
-export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({ students }) => {
+export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
+  students,
+  getStudentAttendanceForDate,
+  updateAttendance
+}) => {
   const [selectedDate, setSelectedDate] = useState(getTodayString());
   const [showSaveConfirmation, setShowSaveConfirmation] = useState(false);
   const [nameFilter, setNameFilter] = useState('');
   const [classFilter, setClassFilter] = useState('');
   const [pendingChanges, setPendingChanges] = useState<Record<string, PendingAttendance>>({});
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  const { getStudentAttendanceForDate, updateAttendance } = useAttendance();
 
   // Obtenir la liste unique des classes
   const availableClasses = useMemo(() => {


### PR DESCRIPTION
## Summary
- pass attendance state from `useAttendance` through `App`
- update `AttendanceEncoder` to use shared state via props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx -y tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68621ab16abc8328af780f07f245052a