### PR TITLE
Remove presence tracking

### DIFF
--- a/src/components/AttendanceEncoder.tsx
+++ b/src/components/AttendanceEncoder.tsx
@@ -65,8 +65,8 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
       
       newPendingChanges[student.id] = {
         studentId: student.id,
-        morningStatus: existingAttendance?.morningStatus || 'I', // Présent par défaut
-        afternoonStatus: existingAttendance?.afternoonStatus || 'I' // Présent par défaut
+        morningStatus: existingAttendance?.morningStatus || '',
+        afternoonStatus: existingAttendance?.afternoonStatus || ''
       };
     });
     
@@ -128,8 +128,8 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
   const getCurrentAttendance = (studentId: string) => {
     return pendingChanges[studentId] || {
       studentId,
-      morningStatus: 'I',
-      afternoonStatus: 'I'
+      morningStatus: '',
+      afternoonStatus: ''
     };
   };
 
@@ -235,12 +235,8 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
       <div className="p-6">
         {/* Bouton d'enregistrement principal */}
         <div className="mb-6 flex items-center justify-between">
-          <div className="grid grid-cols-5 gap-2 text-xs font-medium text-gray-500">
+          <div className="grid grid-cols-4 gap-2 text-xs font-medium text-gray-500">
             <div>Légende:</div>
-            <div className="flex items-center gap-1">
-              <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-              I = Présent
-            </div>
             <div className="flex items-center gap-1">
               <span className="w-2 h-2 bg-blue-500 rounded-full"></span>
               E = Excusé
@@ -329,7 +325,6 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
                           )}
                           className="px-3 py-1 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
                         >
-                          <option value="I">I - Présent</option>
                           <option value="E">E - Excusé</option>
                           <option value="M">M - Certificat</option>
                           <option value="O">O - Non excusé</option>
@@ -350,7 +345,6 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
                           )}
                           className="px-3 py-1 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
                         >
-                          <option value="I">I - Présent</option>
                           <option value="E">E - Excusé</option>
                           <option value="M">M - Certificat</option>
                           <option value="O">O - Non excusé</option>
@@ -395,14 +389,7 @@ export const AttendanceEncoder: React.FC<AttendanceEncoderProps> = ({
 
         {/* Info Section */}
         <div className="mt-6 pt-4 border-t border-gray-200">
-          <div className="flex items-center justify-between">
-            <div className="text-sm text-gray-600 bg-green-50 px-4 py-2 rounded-lg border border-green-200">
-              <span className="flex items-center gap-2">
-                <Check className="w-4 h-4 text-green-600" />
-                Tous les élèves sont marqués "Présent" par défaut
-              </span>
-            </div>
-            
+          <div className="flex items-center justify-end">
             {hasUnsavedChanges && (
               <div className="text-sm text-orange-600 bg-orange-50 px-4 py-2 rounded-lg border border-orange-200">
                 <span className="flex items-center gap-2">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { BarChart3, Users, AlertTriangle, CheckCircle, Mail, ChevronUp, ChevronDown, Minus } from 'lucide-react';
+import { BarChart3, Users, AlertTriangle, Mail, ChevronUp, ChevronDown, Minus } from 'lucide-react';
 import { Student, AttendanceSummary } from '../types';
 import { sendAlertEmail } from '../utils/emailService';
 
@@ -9,7 +9,7 @@ interface DashboardProps {
   addEmailLog: (studentId: string, templateType: 'absence' | 'alert' | 'reminder') => void;
 }
 
-type SortField = 'name' | 'class' | 'present' | 'excused' | 'medical' | 'unjustified';
+type SortField = 'name' | 'class' | 'excused' | 'medical' | 'unjustified';
 type SortDirection = 'asc' | 'desc';
 
 interface ColumnFilter {
@@ -31,7 +31,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
   const totalStudents = students.length;
   const studentsWithAlerts = summaries.filter(s => s.summary.totalUnjustified > 8).length;
   const totalUnjustified = summaries.reduce((acc, s) => acc + s.summary.totalUnjustified, 0);
-  const totalPresent = summaries.reduce((acc, s) => acc + s.summary.totalPresent, 0);
 
   // Fonction pour gérer le tri
   const handleSort = (field: SortField) => {
@@ -47,7 +46,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
   const addColumnFilter = (field: SortField, type: 'min' | 'max') => {
     const values = summaries.map(s => {
       switch (field) {
-        case 'present': return s.summary.totalPresent;
         case 'excused': return s.summary.totalExcused;
         case 'medical': return s.summary.totalMedical;
         case 'unjustified': return s.summary.totalUnjustified;
@@ -87,7 +85,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
       filtered = filtered.filter(item => {
         let value = 0;
         switch (filter.field) {
-          case 'present': value = item.summary.totalPresent; break;
           case 'excused': value = item.summary.totalExcused; break;
           case 'medical': value = item.summary.totalMedical; break;
           case 'unjustified': value = item.summary.totalUnjustified; break;
@@ -111,10 +108,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
         case 'class':
           aValue = a.student.class;
           bValue = b.student.class;
-          break;
-        case 'present':
-          aValue = a.summary.totalPresent;
-          bValue = b.summary.totalPresent;
           break;
         case 'excused':
           aValue = a.summary.totalExcused;
@@ -179,12 +172,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
       icon: BarChart3,
       color: 'bg-orange-500'
     },
-    {
-      title: 'Présences Totales',
-      value: totalPresent,
-      icon: CheckCircle,
-      color: 'bg-green-500'
-    }
   ];
 
   return (
@@ -250,7 +237,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
             {columnFilters.map((filter, index) => (
               <div key={index} className="flex items-center gap-1 bg-blue-100 px-2 py-1 rounded text-sm text-blue-800">
                 <span>
-                  {filter.field === 'present' && 'Présences'}
                   {filter.field === 'excused' && 'Excusées'}
                   {filter.field === 'medical' && 'Médicales'}
                   {filter.field === 'unjustified' && 'Injustifiées'}
@@ -293,42 +279,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
                     Élève
                     {getSortIcon('name')}
                   </button>
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  <div className="flex items-center justify-between">
-                    <button
-                      onClick={() => handleSort('present')}
-                      className="flex items-center hover:text-gray-700 transition-colors"
-                    >
-                      Présences
-                      {getSortIcon('present')}
-                    </button>
-                    <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => addColumnFilter('present', 'min')}
-                        className="p-1 text-green-600 hover:bg-green-100 rounded transition-colors"
-                        title="Filtrer valeur minimum"
-                      >
-                        <ChevronUp className="w-3 h-3" />
-                      </button>
-                      <button
-                        onClick={() => addColumnFilter('present', 'max')}
-                        className="p-1 text-green-600 hover:bg-green-100 rounded transition-colors"
-                        title="Filtrer valeur maximum"
-                      >
-                        <ChevronDown className="w-3 h-3" />
-                      </button>
-                      {getColumnFilter('present') && (
-                        <button
-                          onClick={() => removeColumnFilter('present')}
-                          className="p-1 text-red-600 hover:bg-red-100 rounded transition-colors"
-                          title="Supprimer filtre"
-                        >
-                          <Minus className="w-3 h-3" />
-                        </button>
-                      )}
-                    </div>
-                  </div>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   <div className="flex items-center justify-between">
@@ -458,11 +408,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ students, getAttendanceSum
                         <div className="text-sm text-gray-500">{student.class}</div>
                       </div>
                     </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      {summary.totalPresent}
-                    </span>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">

--- a/src/components/StudentList.tsx
+++ b/src/components/StudentList.tsx
@@ -136,7 +136,7 @@ export const StudentList: React.FC<StudentListProps> = ({
                       </span>
                       {summary.totalUnjustified > 0 && (
                         <div className="text-xs text-gray-500">
-                          ({summary.totalPresent}P, {summary.totalExcused}E, {summary.totalMedical}M)
+                          ({summary.totalExcused}E, {summary.totalMedical}M)
                         </div>
                       )}
                     </div>
@@ -168,9 +168,6 @@ export const StudentList: React.FC<StudentListProps> = ({
         <div className="flex items-center justify-between text-sm text-gray-600">
           <div className="flex items-center gap-4">
             <span>Légende:</span>
-            <div className="flex items-center gap-1">
-              <span className="text-xs">P = Présent</span>
-            </div>
             <div className="flex items-center gap-1">
               <span className="text-xs">E = Excusé</span>
             </div>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -62,13 +62,6 @@ export const mockStudents: Student[] = [
 export const mockAttendanceRecords: AttendanceRecord[] = [
   // Données pour simuler des absences sur plusieurs jours
   {
-    id: '1',
-    studentId: '1',
-    date: '2024-01-15',
-    morningStatus: 'I',
-    afternoonStatus: 'I'
-  },
-  {
     id: '2',
     studentId: '2',
     date: '2024-01-15',
@@ -80,7 +73,7 @@ export const mockAttendanceRecords: AttendanceRecord[] = [
     studentId: '3',
     date: '2024-01-15',
     morningStatus: 'E',
-    afternoonStatus: 'I'
+    afternoonStatus: ''
   },
   {
     id: '4',

--- a/src/hooks/useAttendance.ts
+++ b/src/hooks/useAttendance.ts
@@ -22,7 +22,6 @@ export const useAttendance = () => {
       let totalUnjustified = 0;
       let totalExcused = 0;
       let totalMedical = 0;
-      let totalPresent = 0;
 
       studentRecords.forEach(record => {
         // Matin
@@ -32,8 +31,6 @@ export const useAttendance = () => {
           totalExcused++;
         } else if (record.morningStatus === 'M') {
           totalMedical++;
-        } else if (record.morningStatus === 'I') {
-          totalPresent++;
         }
 
         // Après-midi
@@ -43,8 +40,6 @@ export const useAttendance = () => {
           totalExcused++;
         } else if (record.afternoonStatus === 'M') {
           totalMedical++;
-        } else if (record.afternoonStatus === 'I') {
-          totalPresent++;
         }
       });
 
@@ -52,7 +47,6 @@ export const useAttendance = () => {
         totalUnjustified,
         totalExcused,
         totalMedical,
-        totalPresent,
         records: studentRecords
       });
 
@@ -60,8 +54,7 @@ export const useAttendance = () => {
         studentId,
         totalUnjustified,
         totalExcused,
-        totalMedical,
-        totalPresent
+        totalMedical
       };
     },
     [attendanceRecords]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface Student {
   class: string;
 }
 
-export type AttendanceStatus = 'I' | 'E' | 'M' | 'O' | '';
+export type AttendanceStatus = 'E' | 'M' | 'O' | '';
 
 export interface AttendanceRecord {
   id: string;
@@ -22,7 +22,6 @@ export interface AttendanceSummary {
   totalUnjustified: number;
   totalExcused: number;
   totalMedical: number;
-  totalPresent: number;
 }
 
 export interface EmailLog {
@@ -33,7 +32,6 @@ export interface EmailLog {
 }
 
 export const STATUS_LABELS: Record<AttendanceStatus, string> = {
-  'I': 'Présent',
   'E': 'Excusé',
   'M': 'Certificat médical',
   'O': 'Non excusé',
@@ -41,7 +39,6 @@ export const STATUS_LABELS: Record<AttendanceStatus, string> = {
 };
 
 export const STATUS_COLORS: Record<AttendanceStatus, string> = {
-  'I': 'bg-green-100 text-green-800',
   'E': 'bg-blue-100 text-blue-800',
   'M': 'bg-purple-100 text-purple-800',
   'O': 'bg-red-100 text-red-800',


### PR DESCRIPTION
## Summary
- drop present status from data model
- simplify attendance calculations
- update mock data without presence entries
- remove presence-related UI elements and stats

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b4706a5883289d9bf7f0b675ce65