### PR TITLE
Fix E/M counts for all students

### DIFF
--- a/src/components/StudentList.tsx
+++ b/src/components/StudentList.tsx
@@ -134,11 +134,9 @@ export const StudentList: React.FC<StudentListProps> = ({
                       }`}>
                         {summary.totalUnjustified} demi-jours
                       </span>
-                      {summary.totalUnjustified > 0 && (
-                        <div className="text-xs text-gray-500">
-                          ({summary.totalExcused}E, {summary.totalMedical}M)
-                        </div>
-                      )}
+                      <div className="text-xs text-gray-500">
+                        ({summary.totalExcused}E, {summary.totalMedical}M)
+                      </div>
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- always render excused and medical counts in `StudentList`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686376ba9ef0832890bf738e1b9ca083