### PR TITLE
Remove manual DB seeding

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -42,11 +42,6 @@ app.whenReady().then(() => {
     CREATE TABLE IF NOT EXISTS absences (id INTEGER PRIMARY KEY AUTOINCREMENT, eleve_id INTEGER, date TEXT, motif TEXT, FOREIGN KEY (eleve_id) REFERENCES eleves(id));
   `);
 
-  if (db.prepare('SELECT COUNT(*) AS n FROM eleves').get().n === 0) {
-    const stmt = db.prepare('INSERT INTO eleves (nom, classe) VALUES (?, ?)');
-    stmt.run('Élève de démo 1', 'P1A');
-    stmt.run('Élève de démo 2', 'P2B');
-  }
 
   ipcMain.handle('save-eleve', (_e, d) =>
     db.prepare('INSERT INTO eleves (nom, classe) VALUES (?,?)').run(d.nom, d.classe).lastInsertRowid


### PR DESCRIPTION
## Summary
- stop creating demo records when Electron starts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68658aa34c348328bc1b121acbf7ef07